### PR TITLE
Add wrap_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ Sub::WrapInType does not support wantarray.
 
 This is a wrapper for the constructor.
 
+## wrap\_method(\\@parameter\_types, $return\_type, $subroutine)
+
+This function skips the type check of the first argument:
+
+    sub add {
+      my $class = shift;
+      my ($x, $y) = @_;
+      $x + $y;
+    }
+
+    my $sub = wrap_method [Int, Int], Int, \&add;
+    $sub->(__PACKAGE__, 1, 2); # => 3
+
 # METHODS
 
 ## new(\\@parameter\_types, $return\_type, $subroutine)

--- a/lib/Sub/WrapInType.pm
+++ b/lib/Sub/WrapInType.pm
@@ -14,9 +14,10 @@ use namespace::autoclean;
 our $VERSION = '0.04';
 our @EXPORT  = qw( wrap_sub wrap_method );
 
-readonly params  => my %params;
-readonly returns => my %returns;
-readonly code    => my %code;
+readonly params    => my %params;
+readonly returns   => my %returns;
+readonly code      => my %code;
+readonly is_method => my %is_method;
 
 my $TypeConstraint = HasMethods[qw( assert_valid )];
 my $ParamsTypes    = $TypeConstraint | ArrayRef[$TypeConstraint] | Map[Str, $TypeConstraint];
@@ -89,9 +90,10 @@ EOS
 
   {
     my $addr = id $self;
-    $params{$addr}  = $params_types;
-    $returns{$addr} = $return_types;
-    $code{$addr}    = $code;
+    $params{$addr}    = $params_types;
+    $returns{$addr}   = $return_types;
+    $code{$addr}      = $code;
+    $is_method{$addr} = !!$opts->{skip_invocant};
   }
 
   $self;

--- a/t/01_wrap_sub.t
+++ b/t/01_wrap_sub.t
@@ -122,6 +122,7 @@ subtest 'Confirm get_info' => sub {
   is $typed_code->returns . '', $orig_info->{isa} . '';
   is $typed_code->params . '', $orig_info->{params} . '';
   is $typed_code->code, $orig_info->{code};
+  ok !$typed_code->is_method;
 
 };
 

--- a/t/01_wrap_sub.t
+++ b/t/01_wrap_sub.t
@@ -60,6 +60,14 @@ subtest 'Create typed anonymous subroutine' => sub {
     );
   };
 
+  ok lives {
+    wrap_sub({
+      params => Int,
+      isa    => Int,
+      code   => sub { }
+    });
+  }, 'hashref arguments';
+
   ok dies { wrap_sub }, 'Too few arguments.';
 
   ok dies { wrap_sub \(my $wrap_sub) => Int, sub {} };
@@ -76,6 +84,14 @@ subtest 'Create typed anonymous subroutine' => sub {
       },
     );
   }, 'Wrong key.';
+
+  ok dies {
+    wrap_sub([
+      Int,
+      Int,
+      sub { }
+    ]);
+  }, 'arrayref arguments';
   
 };
 

--- a/t/02_wrap_method.t
+++ b/t/02_wrap_method.t
@@ -17,12 +17,14 @@ sub add_multi {
 subtest 'single return type' => sub {
     my $typed_code = wrap_method [Int, Int] => Int, \&add;
     is $typed_code->(__PACKAGE__, 2, 3), 5;
+    ok $typed_code->is_method;
 };
 
 subtest 'multi return types' => sub {
     my $typed_code = wrap_method [Int, Int] => [Int, Int], \&add_multi;
     my @returns = $typed_code->(__PACKAGE__, 2, 3);
     is \@returns, [5, 6];
+    ok $typed_code->is_method;
 };
 
 done_testing;

--- a/t/02_wrap_method.t
+++ b/t/02_wrap_method.t
@@ -1,0 +1,28 @@
+use Test2::V0;
+use Types::Standard qw( Int );
+use Sub::WrapInType qw( wrap_method );
+
+sub add {
+    my $class = shift;
+    my ($a, $b) = @_;
+    $a + $b;
+};
+
+sub add_multi {
+    my $class = shift;
+    my ($a, $b) = @_;
+    $a + $b, $a * $b
+}
+
+subtest 'single return type' => sub {
+    my $typed_code = wrap_method [Int, Int] => Int, \&add;
+    is $typed_code->(__PACKAGE__, 2, 3), 5;
+};
+
+subtest 'multi return types' => sub {
+    my $typed_code = wrap_method [Int, Int] => [Int, Int], \&add_multi;
+    my @returns = $typed_code->(__PACKAGE__, 2, 3);
+    is \@returns, [5, 6];
+};
+
+done_testing;

--- a/t/03_new.t
+++ b/t/03_new.t
@@ -1,0 +1,83 @@
+use Test2::V0;
+use Types::Standard qw( Int );
+use Sub::WrapInType ();
+
+sub twice { $_[0] * 2 }
+
+subtest 'named / without opts' => sub {
+    my $typed_code = Sub::WrapInType->new(
+        params => [Int],
+        isa    => Int,
+        code   => \&twice,
+    );
+
+    isa_ok $typed_code, 'Sub::WrapInType';
+    is $typed_code->code, \&twice;
+    ok !$typed_code->is_method;
+};
+
+subtest 'named / with opts' => sub {
+    my $typed_code = Sub::WrapInType->new(
+        params => [Int],
+        isa    => Int,
+        code   => \&twice,
+        opts   => { skip_invocant => 1 },
+    );
+
+    isa_ok $typed_code, 'Sub::WrapInType';
+    is $typed_code->code, \&twice;
+    ok $typed_code->is_method;
+};
+
+subtest 'sequenced / without opts' => sub {
+    my $typed_code = Sub::WrapInType->new(
+        [Int],
+        Int,
+        \&twice,
+    );
+
+    isa_ok $typed_code, 'Sub::WrapInType';
+    is $typed_code->code, \&twice;
+    ok !$typed_code->is_method;
+};
+
+subtest 'sequenced / with opts' => sub {
+    my $typed_code = Sub::WrapInType->new(
+        [Int],
+        Int,
+        \&twice,
+        { skip_invocant => 1 },
+    );
+
+    isa_ok $typed_code, 'Sub::WrapInType';
+    is $typed_code->code, \&twice;
+    ok $typed_code->is_method;
+};
+
+
+subtest 'named ref / without opts' => sub {
+    my $typed_code = Sub::WrapInType->new({
+        params => [Int],
+        isa    => Int,
+        code   => \&twice,
+    });
+
+    isa_ok $typed_code, 'Sub::WrapInType';
+    is $typed_code->code, \&twice;
+    ok !$typed_code->is_method;
+};
+
+subtest 'named ref / with opts' => sub {
+    my $typed_code = Sub::WrapInType->new({
+        params => [Int],
+        isa    => Int,
+        code   => \&twice,
+        opts   => { skip_invocant => 1 },
+    });
+
+    isa_ok $typed_code, 'Sub::WrapInType';
+    is $typed_code->code, \&twice;
+    ok $typed_code->is_method;
+};
+
+done_testing;


### PR DESCRIPTION
In this pull request, added a wrap_method that ignores the type check of the first argument as follows:

```perl
sub add {
  my $class = shift;
  my ($x, $y) = @_;
  $x + $y;
}

my $sub = wrap_method [Int, Int], Int, \&add;
$sub->(__PACKAGE__, 1, 2); # => 3
```

This function is useful for wrapping a method.

